### PR TITLE
Add routing and page components

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ The `src` folder will contain the Angular project, organized by components and s
 
 ## Next Steps
 1. Set up the Angular project scaffold.
-2. Implement routing for the Home, About, and Article Details pages.
+2. Implement routing for the Home, About, and Article Details pages. **(done)**
 3. Integrate a news API service to fetch articles.
 4. Create components for the list and detail views.
 5. Style the application for a clean user experience.

--- a/news-consumer/src/app/app-routing.module.ts
+++ b/news-consumer/src/app/app-routing.module.ts
@@ -1,9 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NewsListComponent } from './components/news-list/news-list.component';
+import { AboutComponent } from './components/about/about.component';
+import { ArticleDetailsComponent } from './components/article-details/article-details.component';
 
 const routes: Routes = [
   { path: '', component: NewsListComponent },
+  { path: 'about', component: AboutComponent },
+  { path: 'article/:id', component: ArticleDetailsComponent },
   { path: '**', redirectTo: '' }
 ];
 

--- a/news-consumer/src/app/app.component.html
+++ b/news-consumer/src/app/app.component.html
@@ -304,6 +304,9 @@
 
 <mat-toolbar color="primary">
   <span>News Consumer</span>
+  <span class="spacer"></span>
+  <a mat-button routerLink="">Home</a>
+  <a mat-button routerLink="/about">About</a>
 </mat-toolbar>
 
 <div class="content">

--- a/news-consumer/src/app/app.module.ts
+++ b/news-consumer/src/app/app.module.ts
@@ -11,11 +11,15 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { NewsListComponent } from './components/news-list/news-list.component';
+import { AboutComponent } from './components/about/about.component';
+import { ArticleDetailsComponent } from './components/article-details/article-details.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    NewsListComponent
+    NewsListComponent,
+    AboutComponent,
+    ArticleDetailsComponent
   ],
   imports: [
     BrowserModule,

--- a/news-consumer/src/app/components/about/about.component.html
+++ b/news-consumer/src/app/components/about/about.component.html
@@ -1,0 +1,4 @@
+<div class="about-container">
+  <h1>About</h1>
+  <p>This application displays news articles from public sources.</p>
+</div>

--- a/news-consumer/src/app/components/about/about.component.scss
+++ b/news-consumer/src/app/components/about/about.component.scss
@@ -1,0 +1,3 @@
+.about-container {
+  padding: 20px;
+}

--- a/news-consumer/src/app/components/about/about.component.spec.ts
+++ b/news-consumer/src/app/components/about/about.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AboutComponent } from './about.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AboutComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/news-consumer/src/app/components/about/about.component.ts
+++ b/news-consumer/src/app/components/about/about.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-about',
+  templateUrl: './about.component.html',
+  styleUrls: ['./about.component.scss']
+})
+export class AboutComponent {}

--- a/news-consumer/src/app/components/article-details/article-details.component.html
+++ b/news-consumer/src/app/components/article-details/article-details.component.html
@@ -1,0 +1,4 @@
+<div class="article-details">
+  <h1>Article Details</h1>
+  <p>Showing details for article ID: {{ articleId }}</p>
+</div>

--- a/news-consumer/src/app/components/article-details/article-details.component.scss
+++ b/news-consumer/src/app/components/article-details/article-details.component.scss
@@ -1,0 +1,3 @@
+.article-details {
+  padding: 20px;
+}

--- a/news-consumer/src/app/components/article-details/article-details.component.spec.ts
+++ b/news-consumer/src/app/components/article-details/article-details.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ArticleDetailsComponent } from './article-details.component';
+import { ActivatedRoute } from '@angular/router';
+
+describe('ArticleDetailsComponent', () => {
+  let component: ArticleDetailsComponent;
+  let fixture: ComponentFixture<ArticleDetailsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ArticleDetailsComponent ],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } }
+      ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ArticleDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/news-consumer/src/app/components/article-details/article-details.component.ts
+++ b/news-consumer/src/app/components/article-details/article-details.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-article-details',
+  templateUrl: './article-details.component.html',
+  styleUrls: ['./article-details.component.scss']
+})
+export class ArticleDetailsComponent implements OnInit {
+  articleId: string | null = null;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.articleId = this.route.snapshot.paramMap.get('id');
+  }
+}


### PR DESCRIPTION
## Summary
- implement routing for home, about and article detail pages
- create AboutComponent
- create ArticleDetailsComponent
- add navigation links to About
- mark routing step done in docs

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421f456b708320aa0bf6571e459441