### PR TITLE
Add News API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Create a simple Angular application that:
 - Use RxJS for async data handling
 - Add basic error handling for failed API calls
 
+### API Keys
+API tokens are managed in Angular's `environment` files.
+`src/environments/environment.ts` contains the development keys and
+`environment.prod.ts` holds the production values. The project currently
+includes a token for **The News API**.
+
 ### Evaluation Criteria
 - Code quality and structure
 - Use of Angular best practices

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,10 @@ docs/
 
 The `src` folder will contain the Angular project, organized by components and services. The `docs` folder stores documentation like this project plan.
 
+## API Keys
+API tokens live in the Angular `environment` files. Development and production
+values are provided for **The News API**.
+
 ## Next Steps
 1. Set up the Angular project scaffold.
 2. Implement routing for the Home, About, and Article Details pages. **(done)**

--- a/news-consumer/src/app/services/news.service.ts
+++ b/news-consumer/src/app/services/news.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -8,8 +9,9 @@ import { Observable } from 'rxjs';
 export class NewsService {
   constructor(private http: HttpClient) { }
 
-  // This will be implemented later with actual API calls
   getNews(): Observable<any> {
-    return this.http.get('YOUR_NEWS_API_ENDPOINT');
+    const { baseUrl, token } = environment.newsApi;
+    const url = `${baseUrl}/news/top?categories=science&api_token=${token}`;
+    return this.http.get(url);
   }
 }

--- a/news-consumer/src/environments/environment.prod.ts
+++ b/news-consumer/src/environments/environment.prod.ts
@@ -1,3 +1,7 @@
 export const environment = {
-  production: true
+  production: true,
+  newsApi: {
+    baseUrl: 'https://api.thenewsapi.com/v1',
+    token: 'f10f4341211f466d82f2e909eb926b12'
+  }
 };

--- a/news-consumer/src/environments/environment.ts
+++ b/news-consumer/src/environments/environment.ts
@@ -3,7 +3,11 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  newsApi: {
+    baseUrl: 'https://api.thenewsapi.com/v1',
+    token: 'f10f4341211f466d82f2e909eb926b12'
+  }
 };
 
 /*


### PR DESCRIPTION
## Summary
- manage API keys via Angular environment files
- update NewsService to call The News API
- document key management in README and docs

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684221b4850483208bf33b8548821fa3