### PR TITLE
Implement article detail column with sanitized content

### DIFF
--- a/news-consumer/src/app/components/article-details/article-details.component.html
+++ b/news-consumer/src/app/components/article-details/article-details.component.html
@@ -1,4 +1,16 @@
-<div class="article-details">
-  <h1>Article Details</h1>
-  <p>Showing details for article ID: {{ articleId }}</p>
+<div class="detail-container" *ngIf="article">
+  <a class="back-link" (click)="backToList()">&larr; Back to list</a>
+  <h1 class="headline">{{ article.title }}</h1>
+  <p class="meta">
+    <span class="author" *ngIf="article.author">{{ article.author }}</span>
+    <span class="source">{{ article.source.name }}</span>
+    <span class="date">{{ article.publishedAt | date:'medium' }}</span>
+  </p>
+  <img *ngIf="article.urlToImage" [src]="article.urlToImage" [alt]="article.title">
+  <div class="content" [innerHTML]="safeContent"></div>
+  <a class="external" [href]="article.url" target="_blank">Read original</a>
+</div>
+
+<div class="no-article" *ngIf="!article">
+  <p>Article data not found.</p>
 </div>

--- a/news-consumer/src/app/components/article-details/article-details.component.scss
+++ b/news-consumer/src/app/components/article-details/article-details.component.scss
@@ -1,3 +1,38 @@
-.article-details {
+.detail-container {
+  background: #D2C7B8;
   padding: 20px;
+  font-family: 'Lora', serif;
+}
+
+.headline {
+  font-family: 'Playfair Display', serif;
+  margin-top: 0;
+}
+
+.meta {
+  font-size: 14px;
+  margin-bottom: 20px;
+}
+
+.content {
+  line-height: 1.6;
+  margin-top: 20px;
+}
+
+.back-link {
+  display: none;
+  cursor: pointer;
+  margin-bottom: 10px;
+  color: #947C5F;
+}
+
+.external {
+  display: block;
+  margin-top: 20px;
+}
+
+@media (max-width: 768px) {
+  .back-link {
+    display: block;
+  }
 }

--- a/news-consumer/src/app/components/news-list/news-list.component.ts
+++ b/news-consumer/src/app/components/news-list/news-list.component.ts
@@ -1,12 +1,14 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { NewsService } from '../../services/news.service';
 import { Article } from '../../models/article.interface';
+import { ArticleStateService } from '../../services/article-state.service';
 
 @Component({
   selector: 'app-news-list',
   template: `
     <div class="news-container">
-      <mat-card *ngFor="let article of articles" class="news-card">
+      <mat-card *ngFor="let article of articles; let i = index" class="news-card">
         <mat-card-header>
           <mat-card-title>{{ article.title }}</mat-card-title>
           <mat-card-subtitle>
@@ -24,12 +26,11 @@ import { Article } from '../../models/article.interface';
         </mat-card-content>
         
         <mat-card-actions>
-          <a mat-button 
-             [href]="article.url" 
-             target="_blank" 
-             color="primary">
+          <button mat-button
+                  color="primary"
+                  (click)="openArticle(article, i)">
             READ MORE
-          </a>
+          </button>
         </mat-card-actions>
       </mat-card>
     </div>
@@ -61,7 +62,11 @@ import { Article } from '../../models/article.interface';
 export class NewsListComponent implements OnInit {
   articles: Article[] = [];
 
-  constructor(private newsService: NewsService) {}
+  constructor(
+    private newsService: NewsService,
+    private articleState: ArticleStateService,
+    private router: Router
+  ) {}
 
   ngOnInit() {
     this.loadLatestNews();
@@ -87,5 +92,10 @@ export class NewsListComponent implements OnInit {
         console.error('Error searching news:', error);
       }
     );
+  }
+
+  openArticle(article: Article, index: number) {
+    this.articleState.setArticle(article);
+    this.router.navigate(['/article', index]);
   }
 }

--- a/news-consumer/src/app/services/article-state.service.ts
+++ b/news-consumer/src/app/services/article-state.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Article } from '../models/article.interface';
+
+@Injectable({ providedIn: 'root' })
+export class ArticleStateService {
+  private selected = new BehaviorSubject<Article | null>(null);
+  selected$ = this.selected.asObservable();
+
+  setArticle(article: Article): void {
+    this.selected.next(article);
+  }
+
+  getArticle(): Article | null {
+    return this.selected.value;
+  }
+}


### PR DESCRIPTION
## Summary
- add `ArticleStateService` for passing selected articles
- show sanitized article content in `ArticleDetailsComponent`
- replace inline links with navigation in `NewsListComponent`
- style article details with parchment surface and responsive back link

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842369cab0c83208f8723072757c338