### PR TITLE
Add news aggregator service

### DIFF
--- a/news-consumer/src/app/app.module.ts
+++ b/news-consumer/src/app/app.module.ts
@@ -25,6 +25,8 @@ import { BottomNavComponent } from './components/bottom-nav/bottom-nav.component
 import { ArticleListComponent } from './components/article-list/article-list.component';
 import { ArticleDetailComponent } from './components/article-detail/article-detail.component';
 import { PreferencesComponent } from './components/preferences/preferences.component';
+import { NEWS_SOURCE } from './services/news-source.interface';
+import { TheNewsApiService } from './services/the-news-api.service';
 
 @NgModule({
   declarations: [
@@ -57,7 +59,9 @@ import { PreferencesComponent } from './components/preferences/preferences.compo
     MatInputModule,
     MatFormFieldModule
   ],
-  providers: [],
+  providers: [
+    { provide: NEWS_SOURCE, useExisting: TheNewsApiService, multi: true }
+  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/news-consumer/src/app/components/news-list/news-list.component.ts
+++ b/news-consumer/src/app/components/news-list/news-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NewsService } from '../../services/news.service';
+import { NewsAggregatorService } from '../../services/news-aggregator.service';
 import { SearchService } from '../../services/search.service';
 import { Article } from '../../models/article.interface';
 
@@ -87,7 +88,8 @@ export class NewsListComponent implements OnInit {
 
   constructor(
     private newsService: NewsService,
-    private searchService: SearchService
+    private searchService: SearchService,
+    private aggregator: NewsAggregatorService
   ) {}
 
   ngOnInit() {
@@ -101,9 +103,9 @@ export class NewsListComponent implements OnInit {
     this.loading = true;
     this.error = null;
 
-    this.newsService.getLatestNews().subscribe({
-      next: (response) => {
-        this.articles = response.articles;
+    this.aggregator.getCombinedNews().subscribe({
+      next: (articles) => {
+        this.articles = articles;
         this.selectedArticle = null;
         this.loading = false;
       },

--- a/news-consumer/src/app/components/preferences/preferences.component.ts
+++ b/news-consumer/src/app/components/preferences/preferences.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { PreferencesService } from '../../services/preferences.service';
 
 interface NewsSource {
   id: string;
@@ -238,7 +239,10 @@ export class PreferencesComponent implements OnInit {
     }
   ];
 
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private preferencesService: PreferencesService
+  ) {}
 
   ngOnInit() {
     // Load saved preferences
@@ -246,10 +250,11 @@ export class PreferencesComponent implements OnInit {
     this.isDarkMode = savedTheme === 'dark';
     this.applyTheme();
 
-    const savedSources = localStorage.getItem('newsSources');
-    if (savedSources) {
-      this.newsSources = JSON.parse(savedSources);
-    }
+    const enabled = this.preferencesService.getEnabledSources();
+    this.newsSources = this.newsSources.map(s => ({
+      ...s,
+      enabled: enabled.includes(s.id)
+    }));
   }
 
   goBack() {
@@ -270,7 +275,6 @@ export class PreferencesComponent implements OnInit {
   updateSource(source: NewsSource, event: Event) {
     const checkbox = event.target as HTMLInputElement;
     source.enabled = checkbox.checked;
-    localStorage.setItem('newsSources', JSON.stringify(this.newsSources));
-    // TODO: Emit event to notify news service about source changes
+    this.preferencesService.toggleSource(source.id, source.enabled);
   }
-} 
+}

--- a/news-consumer/src/app/services/news-aggregator.service.ts
+++ b/news-consumer/src/app/services/news-aggregator.service.ts
@@ -1,0 +1,38 @@
+import { Inject, Injectable } from '@angular/core';
+import { combineLatest, Observable, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { Article } from '../models/article.interface';
+import { NEWS_SOURCE, NewsSource } from './news-source.interface';
+import { PreferencesService } from './preferences.service';
+
+@Injectable({ providedIn: 'root' })
+export class NewsAggregatorService {
+  constructor(
+    @Inject(NEWS_SOURCE) private sources: NewsSource[],
+    private preferences: PreferencesService
+  ) {}
+
+  getCombinedNews(): Observable<Article[]> {
+    return this.preferences.enabledSources$.pipe(
+      switchMap(ids => {
+        const observables = this.sources
+          .filter(s => ids.includes(s.id))
+          .map(s => s.getLatestNews());
+        if (observables.length === 0) {
+          return of([]);
+        }
+        return combineLatest(observables).pipe(
+          map(results =>
+            results
+              .reduce((acc, cur) => acc.concat(cur), [])
+              .sort(
+                (a, b) =>
+                  b.publishedAt.getTime() - a.publishedAt.getTime()
+              )
+          )
+        );
+      })
+    );
+  }
+}
+

--- a/news-consumer/src/app/services/news-source.interface.ts
+++ b/news-consumer/src/app/services/news-source.interface.ts
@@ -1,3 +1,4 @@
+import { InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Article } from '../models/article.interface';
 
@@ -6,4 +7,6 @@ export interface NewsSource {
   displayName: string;
   getLatestNews(): Observable<Article[]>;
   searchNews(keyword: string): Observable<Article[]>;
-} 
+}
+
+export const NEWS_SOURCE = new InjectionToken<NewsSource>('NEWS_SOURCE');

--- a/news-consumer/src/app/services/preferences.service.ts
+++ b/news-consumer/src/app/services/preferences.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class PreferencesService {
+  private readonly STORAGE_KEY = 'enabledNewsSources';
+  private enabledSourcesSubject = new BehaviorSubject<string[]>(
+    this.loadEnabledSources()
+  );
+
+  enabledSources$ = this.enabledSourcesSubject.asObservable();
+
+  getEnabledSources(): string[] {
+    return this.enabledSourcesSubject.value;
+  }
+
+  toggleSource(id: string, enabled: boolean): void {
+    const current = this.loadEnabledSources();
+    let updated = current.slice();
+    if (enabled && !updated.includes(id)) {
+      updated.push(id);
+    } else if (!enabled) {
+      updated = updated.filter(s => s !== id);
+    }
+    this.saveEnabledSources(updated);
+  }
+
+  private loadEnabledSources(): string[] {
+    const stored = localStorage.getItem(this.STORAGE_KEY);
+    return stored ? JSON.parse(stored) : ['the-news-api'];
+  }
+
+  private saveEnabledSources(ids: string[]): void {
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(ids));
+    this.enabledSourcesSubject.next(ids);
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `NEWS_SOURCE` token for multi-provider injection
- implement `PreferencesService` to manage enabled news sources
- implement `NewsAggregatorService` that merges results from all enabled sources
- wire `NewsListComponent` to use the aggregator
- update `PreferencesComponent` to use `PreferencesService`
- register `TheNewsApiService` as a `NEWS_SOURCE` provider

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842572841b883209794f0693b2278d1