### PR TITLE
Enable multiple news sources

### DIFF
--- a/news-consumer/src/app/app.module.ts
+++ b/news-consumer/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { ArticleDetailComponent } from './components/article-detail/article-deta
 import { PreferencesComponent } from './components/preferences/preferences.component';
 import { NEWS_SOURCE } from './services/news-source.interface';
 import { TheNewsApiService } from './services/the-news-api.service';
+import { NewsApiOrgService } from './services/news-api-org.service';
 
 @NgModule({
   declarations: [
@@ -60,7 +61,8 @@ import { TheNewsApiService } from './services/the-news-api.service';
     MatFormFieldModule
   ],
   providers: [
-    { provide: NEWS_SOURCE, useExisting: TheNewsApiService, multi: true }
+    { provide: NEWS_SOURCE, useExisting: TheNewsApiService, multi: true },
+    { provide: NEWS_SOURCE, useExisting: NewsApiOrgService, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/news-consumer/src/app/components/news-list/news-list.component.ts
+++ b/news-consumer/src/app/components/news-list/news-list.component.ts
@@ -92,8 +92,6 @@ export class NewsListComponent implements OnInit {
     private newsService: NewsService,
     private searchService: SearchService,
     private prefs: PreferencesService
-
-    private aggregator: NewsAggregatorService
   ) {}
 
   ngOnInit() {
@@ -101,7 +99,7 @@ export class NewsListComponent implements OnInit {
     this.searchService.searchTerm$.subscribe((term: string) => {
       this.searchArticles(term);
     });
-    this.prefs.sourceChange$.subscribe(() => this.loadArticles());
+    this.prefs.enabledSources$.subscribe(() => this.loadArticles());
   }
 
   loadArticles() {

--- a/news-consumer/src/app/components/preferences/preferences.component.ts
+++ b/news-consumer/src/app/components/preferences/preferences.component.ts
@@ -214,28 +214,16 @@ export class PreferencesComponent implements OnInit {
   isDarkMode = false;
   newsSources: NewsSource[] = [
     {
-      id: 'newsapi',
-      name: 'News API',
+      id: 'the-news-api',
+      name: 'The News API',
       enabled: true,
-      description: 'Global news coverage from various sources'
+      description: 'Top stories powered by The News API'
     },
     {
-      id: 'guardian',
-      name: 'The Guardian',
-      enabled: false,
-      description: 'International news and opinion'
-    },
-    {
-      id: 'nyt',
-      name: 'The New York Times',
-      enabled: false,
-      description: 'Breaking news, reviews and opinion'
-    },
-    {
-      id: 'reuters',
-      name: 'Reuters',
-      enabled: false,
-      description: 'Business, financial and world news'
+      id: 'newsapi-org',
+      name: 'NewsAPI.org',
+      enabled: true,
+      description: 'Headlines and articles from NewsAPI.org'
     }
   ];
 

--- a/news-consumer/src/app/services/news-api-org.service.ts
+++ b/news-consumer/src/app/services/news-api-org.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Article } from '../models/article.interface';
+import { environment } from '../../environments/environment';
+import { NewsSource } from './news-source.interface';
+
+@Injectable({ providedIn: 'root' })
+export class NewsApiOrgService implements NewsSource {
+  id = 'newsapi-org';
+  displayName = 'NewsAPI.org';
+  private readonly API_KEY = environment.newsSources.newsApiOrg.token;
+  private readonly BASE_URL = environment.newsSources.newsApiOrg.baseUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getLatestNews(): Observable<Article[]> {
+    const params = new HttpParams()
+      .set('apiKey', this.API_KEY)
+      .set('country', 'us')
+      .set('pageSize', '10');
+
+    return this.http
+      .get<any>(`${this.BASE_URL}/top-headlines`, { params })
+      .pipe(
+        map(res =>
+          res.articles.map((item: any) => ({
+            title: item.title,
+            description: item.description,
+            url: item.url,
+            imageUrl: item.urlToImage,
+            publishedAt: new Date(item.publishedAt),
+            source: item.source?.name || 'NewsAPI.org',
+            categories: []
+          }))
+        )
+      );
+  }
+
+  searchNews(keyword: string): Observable<Article[]> {
+    const params = new HttpParams()
+      .set('apiKey', this.API_KEY)
+      .set('q', keyword)
+      .set('pageSize', '10');
+
+    return this.http
+      .get<any>(`${this.BASE_URL}/everything`, { params })
+      .pipe(
+        map(res =>
+          res.articles.map((item: any) => ({
+            title: item.title,
+            description: item.description,
+            url: item.url,
+            imageUrl: item.urlToImage,
+            publishedAt: new Date(item.publishedAt),
+            source: item.source?.name || 'NewsAPI.org',
+            categories: []
+          }))
+        )
+      );
+  }
+}

--- a/news-consumer/src/app/services/preferences.service.ts
+++ b/news-consumer/src/app/services/preferences.service.ts
@@ -27,7 +27,7 @@ export class PreferencesService {
 
   private loadEnabledSources(): string[] {
     const stored = localStorage.getItem(this.STORAGE_KEY);
-    return stored ? JSON.parse(stored) : ['the-news-api'];
+    return stored ? JSON.parse(stored) : ['the-news-api', 'newsapi-org'];
   }
 
   private saveEnabledSources(ids: string[]): void {


### PR DESCRIPTION
## Summary
- integrate NewsAPI.org as a second `NewsSource`
- register both news services in `AppModule`
- fix duplicate constructor parameter and listen for source changes in `NewsListComponent`
- update Preferences to display toggles for the two available sources
- default both sources to enabled in `PreferencesService`

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842651b20108320b1429211b7cb02e3