### PR TITLE
Add source toggles in preferences

### DIFF
--- a/news-consumer/src/app/components/preferences/preferences.component.ts
+++ b/news-consumer/src/app/components/preferences/preferences.component.ts
@@ -48,6 +48,14 @@ const SOURCE_METADATA: Record<string, { name: string; description: string }> = {
               <h3>{{ source.name }}</h3>
               <p>{{ source.description }}</p>
             </div>
+            <label class="switch">
+              <input
+                type="checkbox"
+                [checked]="source.enabled"
+                (change)="updateSource(source, $event)"
+              />
+              <span class="slider round"></span>
+            </label>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add checkboxes for each news source

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503a1cebc08320acc44f3d5f75d541