### PR TITLE
Add article search component

### DIFF
--- a/news-consumer/src/app/app-routing.module.ts
+++ b/news-consumer/src/app/app-routing.module.ts
@@ -4,10 +4,12 @@ import { NewsListComponent } from './components/news-list/news-list.component';
 import { AboutComponent } from './components/about/about.component';
 import { ArticleDetailsComponent } from './components/article-details/article-details.component';
 import { PreferencesComponent } from './components/preferences/preferences.component';
+import { SearchComponent } from './components/search/search.component';
 
 const routes: Routes = [
   { path: '', component: NewsListComponent },
   { path: 'feed', component: NewsListComponent },
+  { path: 'search', component: SearchComponent },
   { path: 'preferences', component: PreferencesComponent },
   { path: 'about', component: AboutComponent },
   { path: 'article/:id', component: ArticleDetailsComponent },

--- a/news-consumer/src/app/app.module.ts
+++ b/news-consumer/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { BottomNavComponent } from './components/bottom-nav/bottom-nav.component
 import { ArticleListComponent } from './components/article-list/article-list.component';
 import { ArticleDetailComponent } from './components/article-detail/article-detail.component';
 import { PreferencesComponent } from './components/preferences/preferences.component';
+import { SearchComponent } from './components/search/search.component';
 import { NEWS_SOURCE } from './services/news-source.interface';
 import { TheNewsApiService } from './services/the-news-api.service';
 
@@ -39,7 +40,8 @@ import { TheNewsApiService } from './services/the-news-api.service';
     BottomNavComponent,
     ArticleListComponent,
     ArticleDetailComponent,
-    PreferencesComponent
+    PreferencesComponent,
+    SearchComponent
   ],
   imports: [
     BrowserModule,

--- a/news-consumer/src/app/components/search/search.component.html
+++ b/news-consumer/src/app/components/search/search.component.html
@@ -1,0 +1,21 @@
+<div class="search-container">
+  <div class="search-bar">
+    <input
+      type="text"
+      [(ngModel)]="query"
+      (keyup.enter)="onSearch()"
+      placeholder="Search articles"
+    />
+    <button (click)="onSearch()">Search</button>
+  </div>
+
+  <div *ngIf="loading" class="loading">Searching...</div>
+  <div *ngIf="error" class="error">{{ error }}</div>
+
+  <app-article-list
+    *ngIf="!loading && results.length"
+    [articles]="results"
+  ></app-article-list>
+
+  <p *ngIf="!loading && !results.length && query">No results found.</p>
+</div>

--- a/news-consumer/src/app/components/search/search.component.scss
+++ b/news-consumer/src/app/components/search/search.component.scss
@@ -1,0 +1,36 @@
+.search-container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.search-bar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background-color: var(--butler-gold);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.loading,
+.error {
+  margin: 1rem 0;
+}
+
+.error {
+  color: #dc3545;
+}

--- a/news-consumer/src/app/components/search/search.component.ts
+++ b/news-consumer/src/app/components/search/search.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit } from '@angular/core';
+import { of } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { Article } from '../../models/article.interface';
+import { NewsAggregatorService } from '../../services/news-aggregator.service';
+import { SearchService } from '../../services/search.service';
+
+@Component({
+  selector: 'app-search',
+  templateUrl: './search.component.html',
+  styleUrls: ['./search.component.scss']
+})
+export class SearchComponent implements OnInit {
+  query = '';
+  results: Article[] = [];
+  loading = false;
+  error = '';
+
+  constructor(
+    private searchService: SearchService,
+    private aggregator: NewsAggregatorService
+  ) {}
+
+  ngOnInit() {
+    this.searchService.searchTerm$
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap(term => {
+          if (!term.trim()) {
+            this.results = [];
+            return of([]);
+          }
+          this.loading = true;
+          this.error = '';
+          return this.aggregator.searchNews(term);
+        })
+      )
+      .subscribe({
+        next: articles => {
+          this.results = articles;
+          this.loading = false;
+        },
+        error: () => {
+          this.error = 'Error fetching search results';
+          this.loading = false;
+        }
+      });
+  }
+
+  onSearch() {
+    this.searchService.emitSearch(this.query);
+  }
+}

--- a/news-consumer/src/app/components/sidebar-nav/sidebar-nav.component.ts
+++ b/news-consumer/src/app/components/sidebar-nav/sidebar-nav.component.ts
@@ -13,6 +13,12 @@ import { RouterModule } from '@angular/router';
           </a>
         </li>
         <li>
+          <a routerLink="/search" routerLinkActive="active">
+            <i class="fas fa-search"></i>
+            <span>Search</span>
+          </a>
+        </li>
+        <li>
           <a routerLink="/preferences" routerLinkActive="active">
             <i class="fas fa-cog"></i>
             <span>Preferences</span>


### PR DESCRIPTION
## Summary
- add `SearchComponent` for searching news across all sources
- expose the component via `/search` route and sidebar
- register the component in `AppModule`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503f6dd0fc8320a0cfc0a3ca5b939b