### PR TITLE
Add simple bookmarks

### DIFF
--- a/news-consumer/src/app/app-routing.module.ts
+++ b/news-consumer/src/app/app-routing.module.ts
@@ -5,11 +5,13 @@ import { AboutComponent } from './components/about/about.component';
 import { ArticleDetailsComponent } from './components/article-details/article-details.component';
 import { PreferencesComponent } from './components/preferences/preferences.component';
 import { SearchComponent } from './components/search/search.component';
+import { BookmarksComponent } from './components/bookmarks/bookmarks.component';
 
 const routes: Routes = [
   { path: '', component: NewsListComponent },
   { path: 'feed', component: NewsListComponent },
   { path: 'search', component: SearchComponent },
+  { path: 'bookmarks', component: BookmarksComponent },
   { path: 'preferences', component: PreferencesComponent },
   { path: 'about', component: AboutComponent },
   { path: 'article/:id', component: ArticleDetailsComponent },

--- a/news-consumer/src/app/app.module.ts
+++ b/news-consumer/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { ArticleListComponent } from './components/article-list/article-list.com
 import { ArticleDetailComponent } from './components/article-detail/article-detail.component';
 import { PreferencesComponent } from './components/preferences/preferences.component';
 import { SearchComponent } from './components/search/search.component';
+import { BookmarksComponent } from './components/bookmarks/bookmarks.component';
 import { NEWS_SOURCE } from './services/news-source.interface';
 import { TheNewsApiService } from './services/the-news-api.service';
 
@@ -41,7 +42,8 @@ import { TheNewsApiService } from './services/the-news-api.service';
     ArticleListComponent,
     ArticleDetailComponent,
     PreferencesComponent,
-    SearchComponent
+    SearchComponent,
+    BookmarksComponent
   ],
   imports: [
     BrowserModule,

--- a/news-consumer/src/app/components/article-detail/article-detail.component.ts
+++ b/news-consumer/src/app/components/article-detail/article-detail.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Article } from '../../models/article.interface';
+import { BookmarkService } from '../../services/bookmark.service';
 
 @Component({
   selector: 'app-article-detail',
@@ -7,10 +8,24 @@ import { Article } from '../../models/article.interface';
     <div class="article-detail">
       <h2>{{ article.title }}</h2>
       <span *ngIf="article.source">• {{ article.source }}</span>
-      <img *ngIf="article.imageUrl" [src]="article.imageUrl" [alt]="article.title" class="detail-image" (error)="onImgError($event)">
+      <img
+        *ngIf="article.imageUrl"
+        [src]="article.imageUrl"
+        [alt]="article.title"
+        class="detail-image"
+        (error)="onImgError($event)"
+      >
       <p *ngIf="article.description">{{ article.description }}</p>
+      <button class="bookmark-btn" (click)="toggleBookmark()">
+        {{ bookmarked ? 'Remove Bookmark' : 'Bookmark' }}
+      </button>
       <ng-content></ng-content>
-      <a *ngIf="article.url" [href]="article.url" target="_blank" rel="noopener">Read full article</a>
+      <a
+        *ngIf="article.url"
+        [href]="article.url"
+        target="_blank"
+        rel="noopener"
+      >Read full article</a>
     </div>
   `,
   styles: [`
@@ -19,12 +34,32 @@ import { Article } from '../../models/article.interface';
     h2 { margin-bottom: 0.5rem; }
     span { color: #888; font-size: 0.9rem; margin-bottom: 1rem; display: block; }
     a { display: inline-block; margin-top: 1rem; color: #007bff; }
+    .bookmark-btn {
+      margin-top: 1rem;
+    }
   `]
 })
 export class ArticleDetailComponent {
   @Input() article!: Article;
+  bookmarked = false;
+
+  constructor(private bookmarks: BookmarkService) {}
+
+  ngOnInit(): void {
+    this.bookmarked = this.bookmarks.isBookmarked(this.article);
+  }
 
   onImgError(event: Event) {
     (event.target as HTMLImageElement).style.display = 'none';
   }
-} 
+
+  toggleBookmark() {
+    if (this.bookmarked) {
+      this.bookmarks.remove(this.article);
+      this.bookmarked = false;
+    } else {
+      this.bookmarks.add(this.article);
+      this.bookmarked = true;
+    }
+  }
+}

--- a/news-consumer/src/app/components/bookmarks/bookmarks.component.ts
+++ b/news-consumer/src/app/components/bookmarks/bookmarks.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { BookmarkService } from '../../services/bookmark.service';
+import { Article } from '../../models/article.interface';
+
+@Component({
+  selector: 'app-bookmarks',
+  template: `
+    <div class="bookmarks-container">
+      <h1>Bookmarks</h1>
+      <p *ngIf="bookmarks.length === 0">No bookmarks yet.</p>
+      <app-article-list
+        *ngIf="bookmarks.length"
+        [articles]="bookmarks"
+        (articleSelected)="selected = $event">
+      </app-article-list>
+      <app-article-detail
+        *ngIf="selected"
+        [article]="selected">
+      </app-article-detail>
+    </div>
+  `,
+  styles: [`
+    .bookmarks-container {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+  `]
+})
+export class BookmarksComponent implements OnInit {
+  bookmarks: Article[] = [];
+  selected: Article | null = null;
+
+  constructor(private bookmarksSvc: BookmarkService) {}
+
+  ngOnInit(): void {
+    this.bookmarks = this.bookmarksSvc.getBookmarks();
+  }
+}

--- a/news-consumer/src/app/components/bottom-nav/bottom-nav.component.ts
+++ b/news-consumer/src/app/components/bottom-nav/bottom-nav.component.ts
@@ -1,36 +1,28 @@
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-bottom-nav',
   template: `
     <nav class="butler-bottom-nav" aria-label="Bottom navigation">
-      <button
-        *ngFor="let item of navItems; let i = index"
+      <a
+        *ngFor="let item of navItems"
         class="bottom-nav-btn"
-        [class.active]="activeIndex === i"
-        (click)="onNav(i)"
-        [attr.aria-current]="activeIndex === i ? 'page' : null"
-        tabindex="0"
+        routerLink="{{ item.path }}"
+        routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: true }"
         [attr.aria-label]="item.label"
       >
         <span class="material-icons">{{ item.icon }}</span>
         <span class="nav-label">{{ item.label }}</span>
-      </button>
+      </a>
     </nav>
   `,
   styleUrls: ['./bottom-nav.component.scss']
 })
 export class BottomNavComponent {
-  @Output() navigate = new EventEmitter<string>();
   navItems = [
-    { label: 'Home', icon: 'home' },
-    { label: 'Bookmarks', icon: 'bookmark' },
-    { label: 'Info', icon: 'info' }
+    { label: 'Home', icon: 'home', path: '/' },
+    { label: 'Bookmarks', icon: 'bookmark', path: '/bookmarks' },
+    { label: 'Info', icon: 'info', path: '/about' }
   ];
-  activeIndex = 0;
-
-  onNav(index: number) {
-    this.activeIndex = index;
-    this.navigate.emit(this.navItems[index].label);
-  }
-} 
+}

--- a/news-consumer/src/app/components/sidebar-nav/sidebar-nav.component.ts
+++ b/news-consumer/src/app/components/sidebar-nav/sidebar-nav.component.ts
@@ -19,6 +19,12 @@ import { RouterModule } from '@angular/router';
           </a>
         </li>
         <li>
+          <a routerLink="/bookmarks" routerLinkActive="active">
+            <i class="fas fa-bookmark"></i>
+            <span>Bookmarks</span>
+          </a>
+        </li>
+        <li>
           <a routerLink="/preferences" routerLinkActive="active">
             <i class="fas fa-cog"></i>
             <span>Preferences</span>

--- a/news-consumer/src/app/services/bookmark.service.ts
+++ b/news-consumer/src/app/services/bookmark.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { Article } from '../models/article.interface';
+
+@Injectable({ providedIn: 'root' })
+export class BookmarkService {
+  private STORAGE_KEY = 'bookmarkedArticles';
+
+  getBookmarks(): Article[] {
+    const data = localStorage.getItem(this.STORAGE_KEY);
+    if (!data) {
+      return [];
+    }
+    try {
+      return JSON.parse(data);
+    } catch {
+      return [];
+    }
+  }
+
+  isBookmarked(article: Article): boolean {
+    return this.getBookmarks().some(a => a.url === article.url);
+  }
+
+  add(article: Article): void {
+    const bookmarks = this.getBookmarks();
+    if (!bookmarks.some(a => a.url === article.url)) {
+      bookmarks.push(article);
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(bookmarks));
+    }
+  }
+
+  remove(article: Article): void {
+    const updated = this.getBookmarks().filter(a => a.url !== article.url);
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(updated));
+  }
+}


### PR DESCRIPTION
## Summary
- implement `BookmarkService` for storing saved articles in local storage
- add new `BookmarksComponent` and route
- display bookmark toggle in article details
- link to Bookmarks from sidebar and bottom navigation

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685046d0b2ac8320ac1e1f23a20d6915