### PR TITLE
Add infinite scroll to news list

### DIFF
--- a/news-consumer/src/app/services/news-aggregator.service.ts
+++ b/news-consumer/src/app/services/news-aggregator.service.ts
@@ -26,14 +26,14 @@ export class NewsAggregatorService {
     }
   }
 
-  getLatestNews(): Observable<Article[]> {
+  getLatestNews(page = 1): Observable<Article[]> {
     const enabledIds: string[] = this.getEnabledSourceIds();
     if (enabledIds.length === 0) {
       return of([]);
     }
     const observables: Observable<Article[]>[] = enabledIds
       .filter((id: string) => this.sources[id])
-      .map((id: string) => this.sources[id].getLatestNews().pipe(
+      .map((id: string) => this.sources[id].getLatestNews(page).pipe(
         catchError(() => of([]))
       ));
     return forkJoin(observables).pipe(

--- a/news-consumer/src/app/services/news-source.interface.ts
+++ b/news-consumer/src/app/services/news-source.interface.ts
@@ -5,7 +5,7 @@ import { Article } from '../models/article.interface';
 export interface NewsSource {
   id: string;
   displayName: string;
-  getLatestNews(): Observable<Article[]>;
+  getLatestNews(page?: number): Observable<Article[]>;
   searchNews(keyword: string): Observable<Article[]>;
 }
 

--- a/news-consumer/src/app/services/the-news-api.service.ts
+++ b/news-consumer/src/app/services/the-news-api.service.ts
@@ -17,11 +17,12 @@ export class TheNewsApiService implements NewsSource {
 
   constructor(private http: HttpClient) {}
 
-  getLatestNews(): Observable<Article[]> {
+  getLatestNews(page = 1): Observable<Article[]> {
     const params = new HttpParams()
       .set('api_token', this.API_KEY)
       .set('language', 'en')
-      .set('limit', '10');
+      .set('limit', '10')
+      .set('page', String(page));
 
     return this.http.get<any>(`${this.BASE_URL}/news/top`, { params }).pipe(
       map((response: any) => response.data.map((item: any) => ({


### PR DESCRIPTION
## Summary
- update `NewsSource` interface to accept an optional page argument
- pass page info through `NewsAggregatorService`
- update `TheNewsApiService` to request a specific page
- implement scrolling-based pagination in `NewsListComponent`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504cf5dc2083208407566d1f0164b7