### PR TITLE
Add map generation and validation utilities

### DIFF
--- a/news-consumer/src/app/utils/map-generator.ts
+++ b/news-consumer/src/app/utils/map-generator.ts
@@ -1,0 +1,59 @@
+import { Cell, Position, GeneratedMap } from './map-types';
+import { validateMap } from './map-validator';
+
+function randomInt(max: number): number {
+  return Math.floor(Math.random() * max);
+}
+
+function placeShelves(
+  grid: Cell[][],
+  shelfCount: number,
+  forbidden: Set<string>
+): Position[] {
+  const shelves: Position[] = [];
+  const rows = grid.length;
+  const cols = grid[0].length;
+
+  while (shelves.length < shelfCount) {
+    const r = randomInt(rows);
+    const c = randomInt(cols);
+    const key = `${r},${c}`;
+    if (!forbidden.has(key)) {
+      grid[r][c] = 'S';
+      shelves.push({ row: r, col: c });
+      forbidden.add(key);
+    }
+  }
+  return shelves;
+}
+
+export function generateMap(
+  rows: number,
+  cols: number,
+  shelfCount: number,
+  maxAttempts = 50
+): GeneratedMap {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const grid: Cell[][] = Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, () => ' ')
+    );
+
+    const entry: Position = { row: 0, col: randomInt(cols) };
+    const exit: Position = { row: rows - 1, col: randomInt(cols) };
+
+    grid[entry.row][entry.col] = 'E';
+    grid[exit.row][exit.col] = 'X';
+
+    const forbidden = new Set<string>();
+    forbidden.add(`${entry.row},${entry.col}`);
+    forbidden.add(`${exit.row},${exit.col}`);
+
+    const shelves = placeShelves(grid, shelfCount, forbidden);
+
+    const map = { grid, entry, exit, shelves } as GeneratedMap;
+    if (validateMap(map)) {
+      return map;
+    }
+  }
+  throw new Error('Failed to generate a valid map');
+}

--- a/news-consumer/src/app/utils/map-types.ts
+++ b/news-consumer/src/app/utils/map-types.ts
@@ -1,0 +1,13 @@
+export type Cell = ' ' | 'S' | 'E' | 'X';
+
+export interface Position {
+  row: number;
+  col: number;
+}
+
+export interface GeneratedMap {
+  grid: Cell[][];
+  entry: Position;
+  exit: Position;
+  shelves: Position[];
+}

--- a/news-consumer/src/app/utils/map-validator.ts
+++ b/news-consumer/src/app/utils/map-validator.ts
@@ -1,0 +1,67 @@
+import { GeneratedMap, Position } from './map-types';
+
+export function validateMap(map: GeneratedMap): boolean {
+  const rows = map.grid.length;
+  const cols = map.grid[0].length;
+  const visited = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => false)
+  );
+
+  const queue: Position[] = [map.entry];
+  visited[map.entry.row][map.entry.col] = true;
+
+  const directions = [
+    { dr: 1, dc: 0 },
+    { dr: -1, dc: 0 },
+    { dr: 0, dc: 1 },
+    { dr: 0, dc: -1 }
+  ];
+
+  while (queue.length) {
+    const cur = queue.shift()!;
+    for (const d of directions) {
+      const nr = cur.row + d.dr;
+      const nc = cur.col + d.dc;
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        !visited[nr][nc]
+      ) {
+        const cell = map.grid[nr][nc];
+        if (cell === ' ' || cell === 'X') {
+          visited[nr][nc] = true;
+          queue.push({ row: nr, col: nc });
+        }
+      }
+    }
+  }
+
+  if (!visited[map.exit.row][map.exit.col]) {
+    return false;
+  }
+
+  for (const s of map.shelves) {
+    let reachable = false;
+    for (const d of directions) {
+      const nr = s.row + d.dr;
+      const nc = s.col + d.dc;
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        visited[nr][nc]
+      ) {
+        reachable = true;
+        break;
+      }
+    }
+    if (!reachable) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- implement new map utilities
- generate maps with shelves, entry and exit
- ensure generated maps are valid with a validator

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6ff2a90483208c2355eaf5e7c119