### PR TITLE
Add shelf type clustering and product assignment utilities

### DIFF
--- a/news-consumer/src/app/models/product.interface.ts
+++ b/news-consumer/src/app/models/product.interface.ts
@@ -1,0 +1,8 @@
+import { ShelfType } from '../utils/map-types';
+
+export interface Product {
+  id: number;
+  name: string;
+  type: ShelfType;
+  price: number;
+}

--- a/news-consumer/src/app/utils/map-generator.ts
+++ b/news-consumer/src/app/utils/map-generator.ts
@@ -1,0 +1,105 @@
+import { Cell, GeneratedMap, Position, Shelf, ShelfType } from './map-types';
+import { validateMap } from './map-validator';
+
+function randomInt(max: number): number {
+  return Math.floor(Math.random() * max);
+}
+
+function cellForType(type: ShelfType): Cell {
+  switch (type) {
+    case 'cold':
+      return 'C';
+    case 'bakery':
+      return 'B';
+    case 'dairy':
+      return 'D';
+    case 'fresh':
+      return 'F';
+  }
+}
+
+function placeCluster(
+  grid: Cell[][],
+  type: ShelfType,
+  count: number,
+  forbidden: Set<string>
+): Shelf[] {
+  const shelves: Shelf[] = [];
+  if (count <= 0) {
+    return shelves;
+  }
+  const rows = grid.length;
+  const cols = grid[0].length;
+
+  const orientation = randomInt(2) === 0 ? 'h' : 'v';
+  for (let attempt = 0; attempt < 100; attempt++) {
+    const rLimit = orientation === 'v' ? rows - count + 1 : rows;
+    const cLimit = orientation === 'h' ? cols - count + 1 : cols;
+    if (rLimit <= 0 || cLimit <= 0) {
+      break;
+    }
+    const r = randomInt(rLimit);
+    const c = randomInt(cLimit);
+    let valid = true;
+    for (let i = 0; i < count; i++) {
+      const nr = orientation === 'h' ? r : r + i;
+      const nc = orientation === 'h' ? c + i : c;
+      const key = `${nr},${nc}`;
+      if (forbidden.has(key)) {
+        valid = false;
+        break;
+      }
+    }
+    if (!valid) {
+      continue;
+    }
+    for (let i = 0; i < count; i++) {
+      const nr = orientation === 'h' ? r : r + i;
+      const nc = orientation === 'h' ? c + i : c;
+      grid[nr][nc] = cellForType(type);
+      forbidden.add(`${nr},${nc}`);
+      shelves.push({ position: { row: nr, col: nc }, type });
+    }
+    return shelves;
+  }
+  throw new Error('Failed to place shelf cluster');
+}
+
+export function generateMap(
+  rows: number,
+  cols: number,
+  shelfConfig: Record<ShelfType, number>,
+  maxAttempts = 50
+): GeneratedMap {
+  const types: ShelfType[] = ['cold', 'bakery', 'dairy', 'fresh'];
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const grid: Cell[][] = Array.from({ length: rows }, () =>
+      Array.from({ length: cols }, () => ' ')
+    );
+
+    const entry: Position = { row: 0, col: randomInt(cols) };
+    const exit: Position = { row: rows - 1, col: randomInt(cols) };
+    grid[entry.row][entry.col] = 'E';
+    grid[exit.row][exit.col] = 'X';
+
+    const forbidden = new Set<string>();
+    forbidden.add(`${entry.row},${entry.col}`);
+    forbidden.add(`${exit.row},${exit.col}`);
+
+    let shelves: Shelf[] = [];
+    try {
+      for (const t of types) {
+        const count = shelfConfig[t] || 0;
+        shelves = shelves.concat(placeCluster(grid, t, count, forbidden));
+      }
+    } catch (e) {
+      continue;
+    }
+
+    const map: GeneratedMap = { grid, entry, exit, shelves };
+    if (validateMap(map)) {
+      return map;
+    }
+  }
+  throw new Error('Failed to generate a valid map');
+}

--- a/news-consumer/src/app/utils/map-types.ts
+++ b/news-consumer/src/app/utils/map-types.ts
@@ -1,0 +1,27 @@
+export type ShelfType = 'cold' | 'bakery' | 'dairy' | 'fresh';
+
+export type Cell =
+  | ' '
+  | 'E'
+  | 'X'
+  | 'C'
+  | 'B'
+  | 'D'
+  | 'F';
+
+export interface Position {
+  row: number;
+  col: number;
+}
+
+export interface Shelf {
+  position: Position;
+  type: ShelfType;
+}
+
+export interface GeneratedMap {
+  grid: Cell[][];
+  entry: Position;
+  exit: Position;
+  shelves: Shelf[];
+}

--- a/news-consumer/src/app/utils/map-validator.ts
+++ b/news-consumer/src/app/utils/map-validator.ts
@@ -1,0 +1,67 @@
+import { Cell, GeneratedMap, Position } from './map-types';
+
+export function validateMap(map: GeneratedMap): boolean {
+  const rows = map.grid.length;
+  const cols = map.grid[0].length;
+  const visited = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => false)
+  );
+
+  const queue: Position[] = [map.entry];
+  visited[map.entry.row][map.entry.col] = true;
+
+  const directions = [
+    { dr: 1, dc: 0 },
+    { dr: -1, dc: 0 },
+    { dr: 0, dc: 1 },
+    { dr: 0, dc: -1 }
+  ];
+
+  while (queue.length) {
+    const cur = queue.shift()!;
+    for (const d of directions) {
+      const nr = cur.row + d.dr;
+      const nc = cur.col + d.dc;
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        !visited[nr][nc]
+      ) {
+        const cell: Cell = map.grid[nr][nc];
+        if (cell === ' ' || cell === 'X' || cell === 'E') {
+          visited[nr][nc] = true;
+          queue.push({ row: nr, col: nc });
+        }
+      }
+    }
+  }
+
+  if (!visited[map.exit.row][map.exit.col]) {
+    return false;
+  }
+
+  for (const s of map.shelves) {
+    let reachable = false;
+    for (const d of directions) {
+      const nr = s.position.row + d.dr;
+      const nc = s.position.col + d.dc;
+      if (
+        nr >= 0 &&
+        nr < rows &&
+        nc >= 0 &&
+        nc < cols &&
+        visited[nr][nc]
+      ) {
+        reachable = true;
+        break;
+      }
+    }
+    if (!reachable) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/news-consumer/src/app/utils/product-placement.ts
+++ b/news-consumer/src/app/utils/product-placement.ts
@@ -1,0 +1,37 @@
+import { Product } from '../models/product.interface';
+import { GeneratedMap, ShelfType } from './map-types';
+
+function randomInt(max: number): number {
+  return Math.floor(Math.random() * max);
+}
+
+export function assignProductsToShelves(
+  products: Product[],
+  map: GeneratedMap
+): Record<string, Product[]> {
+  const placement: Record<string, Product[]> = {};
+  const byType: Record<ShelfType, { row: number; col: number }[]> = {
+    cold: [],
+    bakery: [],
+    dairy: [],
+    fresh: []
+  };
+
+  for (const shelf of map.shelves) {
+    const key = `${shelf.position.row},${shelf.position.col}`;
+    placement[key] = [];
+    byType[shelf.type].push(shelf.position);
+  }
+
+  for (const product of products) {
+    const shelves = byType[product.type];
+    if (!shelves.length) {
+      continue;
+    }
+    const pos = shelves[randomInt(shelves.length)];
+    const key = `${pos.row},${pos.col}`;
+    placement[key].push(product);
+  }
+
+  return placement;
+}


### PR DESCRIPTION
## Summary
- expand map types with specific shelf categories
- generate maps that cluster shelves by type
- validate maps with new shelf structure
- create product model and assign products to matching shelves

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c6ff2a90483208c2355eaf5e7c119